### PR TITLE
Aria 561

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -331,6 +331,13 @@ def get_objects_all(prod_type, location=False, starttime=False, endtime=False, f
         raise RuntimeError("0 matching found for {} with full_id_hash {}".format(prod_type, full_id_hash))
 
     #print(results)
+    '''
+    res = []
+    [res.append(x) for x in total_results if x not in res]
+    #total_results = list(set(total_results))
+    print(res)
+    return res
+    '''
     return total_results
     
     
@@ -562,6 +569,11 @@ def get_orbit(es_obj):
             return stringify_orbit(orbit)
     raise Exception('unable to find orbit for: {}'.format(es_obj.get('_id', '')))
 
+def remove_local(s, suffix):
+    if suffix and s.endswith(suffix):
+        return s[:-len(suffix)]
+    return s
+
 def get_hash(es_obj):
     '''retrieves the full_id_hash. if it doesn't exists, it
         attempts to generate one'''
@@ -580,6 +592,7 @@ def gen_hash(es_obj):
     for slc in sorted(master_slcs):
         if isinstance(slc, tuple) or isinstance(slc, list):
             slc = slc[0]
+        slc = remove_local(slc, "-local")
         if master_ids_str == "":
             master_ids_str = slc
         else:
@@ -587,6 +600,7 @@ def gen_hash(es_obj):
     for slc in sorted(slave_slcs):
         if isinstance(slc, tuple) or isinstance(slc, list):
             slc = slc[0]
+        slc = remove_local(slc, "-local")
         if slave_ids_str == "":
             slave_ids_str = slc
         else:

--- a/evaluate.py
+++ b/evaluate.py
@@ -394,8 +394,7 @@ def get_objects(prod_type, location=False, starttime=False, endtime=False, full_
 
 def print_query(prod_type, location=False, starttime=False, endtime=False, full_id_hash=False, track_number=False, orbit_numbers=False, version=False, uid=False, aoi=False):
     '''print statement describing grq query'''
-    prod_types = prod_type.split(',')
-    statement = 'Querying for products of type: {}'.format(prod_types)
+    statement = 'Querying for products of type: {}'.format(prod_type)
     if location:
         statement += '\nwith location:     {}'.format(location)
     if starttime:

--- a/evaluate.py
+++ b/evaluate.py
@@ -331,7 +331,7 @@ def get_objects_all(prod_type, location=False, starttime=False, endtime=False, f
         raise RuntimeError("0 matching found for {} with full_id_hash {}".format(prod_type, full_id_hash))
 
     #print(results)
-    return results
+    return total_results
     
     
 def get_objects(prod_type, location=False, starttime=False, endtime=False, full_id_hash=False, track_number=False, orbit_numbers=False, version=False, uid=False, aoi=False):


### PR DESCRIPTION
Completeness Evaluator Failing for On Demand IFGs
Completeness evaluator needs refactoring to work on Pleiades pipeline.

Currently, no Pleiades products are being published
Estimated 6,000 GUNW’s that have not been published that should have been published as a result of aoi track completeness.
Datasets to look at that affect completeness evaluator functionality:
AWS:
S1-GUNW-acqlist-audit_trail
S1-GUNW-acq-list
S1-IW_SLC
S1-GUNW-ifg-cfg
Pleiades:
runconfig-acqlist-audit_trail
runconfig-acq-list
S1-IW_SLC-local
Runconfig-topsapp
S1-IW_SLC-local ids are suffixed with ‘-local’ in ES
New products are referencing these new ids, whereas old products are referencing the un-suffixed ids
gen_hash relies on slc id, so intermediate products are being produced with different hashes